### PR TITLE
Front 17 link pages

### DIFF
--- a/src/editor/common/inputs/page-selector/PageSelector.tsx
+++ b/src/editor/common/inputs/page-selector/PageSelector.tsx
@@ -11,12 +11,13 @@ interface Props {
   pages: Page[];
   target: JSX.Element;
   onSelect: (page: Page) => void;
+  noResultsText?: string;
 }
 
 @observer
 export class PageSelector extends React.Component<Props> {
   public render() {
-    const { pages, target } = this.props;
+    const { pages, target, noResultsText } = this.props;
 
     return (
       <PageSelect
@@ -24,7 +25,7 @@ export class PageSelector extends React.Component<Props> {
         itemRenderer={this.pageItemRenderer}
         onItemSelect={this.onPageItemSelect}
         itemPredicate={this.filterPages}
-        noResults={<MenuItem text={'No matching pages!'} disabled />}
+        noResults={<MenuItem text={noResultsText ?? 'No matching pages!'} disabled />}
       >
         {target}
       </PageSelect>

--- a/src/editor/common/state/PageItem.ts
+++ b/src/editor/common/state/PageItem.ts
@@ -2,23 +2,19 @@ import { CSSProperties } from 'react';
 import { ColorResult } from 'react-color';
 import { action, observable } from 'mobx';
 
+import { Page } from './Page';
 import { RandomUtils } from '../../../utils/RandomUtils';
 import { TextSettings } from './TextSettings';
-import { Vector } from '../../../utils/Vector';
-
-//import { pageDisplayUtil } from '../../utils/PageDisplayUtils';
-
-
-
 
 export class PageItem {
   public id = RandomUtils.createId();
   @observable public settings: CSSProperties = {};
   @observable public textSettings = new TextSettings();
-  @observable public left: string;
-  @observable public top: string;
-  @observable public width: string;
-  @observable public height: string;
+  @observable.ref public left: string;
+  @observable.ref public top: string;
+  @observable.ref public width: string;
+  @observable.ref public height: string;
+  @observable.ref public linkedPage?: Page;
 
   constructor(left = '0', top = '0', width = '0', height = '0') {
     this.setLeft(left);
@@ -50,5 +46,13 @@ export class PageItem {
   @action public setBackgroundColor = (color: ColorResult) => {
     const rgba = color.rgb;
     this.settings.backgroundColor = `rgba( ${rgba.r}, ${rgba.g}, ${rgba.b}, ${rgba.a})`;
+  };
+
+  @action public setLinkedPage = (page: Page) => {
+    this.linkedPage = page;
+  };
+
+  @action public unlinkPage = () => {
+    this.linkedPage = undefined;
   };
 }

--- a/src/editor/events/StoryEventObserver.ts
+++ b/src/editor/events/StoryEventObserver.ts
@@ -4,13 +4,15 @@ export enum StoryEventType {
   ANY = 'event-any', // encompasses all event types
   NEW_PAGE = 'event-new-page',
   RENAME_PAGE = 'event-rename-page',
-  LINK_PAGES = 'event-link-pages',
+  LINK_PAGE_ITEM = 'event-link-pages',
+  UNLINK_PAGE_ITEM = 'event-unlink-page',
 }
 
 export type StoryEvent =
   | { type: StoryEventType.NEW_PAGE; page: Page }
   | { type: StoryEventType.RENAME_PAGE; page: Page }
-  | { type: StoryEventType.LINK_PAGES; fromId: string; toId: string };
+  | { type: StoryEventType.LINK_PAGE_ITEM; itemId: string; fromId: string; toId: string }
+  | { type: StoryEventType.UNLINK_PAGE_ITEM; itemId: string };
 
 type StoryEventListener = (event: StoryEvent) => void;
 

--- a/src/editor/events/StoryEventObserver.ts
+++ b/src/editor/events/StoryEventObserver.ts
@@ -4,11 +4,13 @@ export enum StoryEventType {
   ANY = 'event-any', // encompasses all event types
   NEW_PAGE = 'event-new-page',
   RENAME_PAGE = 'event-rename-page',
+  LINK_PAGES = 'event-link-pages',
 }
 
 export type StoryEvent =
   | { type: StoryEventType.NEW_PAGE; page: Page }
-  | { type: StoryEventType.RENAME_PAGE; page: Page };
+  | { type: StoryEventType.RENAME_PAGE; page: Page }
+  | { type: StoryEventType.LINK_PAGES; fromId: string; toId: string };
 
 type StoryEventListener = (event: StoryEvent) => void;
 

--- a/src/editor/page-inspector/components/PageInspector.tsx
+++ b/src/editor/page-inspector/components/PageInspector.tsx
@@ -29,7 +29,10 @@ export class PageInspector extends React.Component<Props> {
             <PageDetails page={selectedPage} />
           </div>
           <div className={'sub-details-area'}>
-            <PageItemDetails pageItem={selectedPage.selectedItem} />
+            <PageItemDetails
+              pageItem={selectedPage.selectedItem}
+              linkablePages={inspectorState.getLinkablePages()}
+            />
           </div>
         </div>
       </div>

--- a/src/editor/page-inspector/components/PageInspector.tsx
+++ b/src/editor/page-inspector/components/PageInspector.tsx
@@ -32,6 +32,7 @@ export class PageInspector extends React.Component<Props> {
             <PageItemDetails
               pageItem={selectedPage.selectedItem}
               linkablePages={inspectorState.getLinkablePages()}
+              onLinkPage={inspectorState.onLinkPage}
             />
           </div>
         </div>

--- a/src/editor/page-inspector/components/PageInspector.tsx
+++ b/src/editor/page-inspector/components/PageInspector.tsx
@@ -32,7 +32,8 @@ export class PageInspector extends React.Component<Props> {
             <PageItemDetails
               pageItem={selectedPage.selectedItem}
               linkablePages={inspectorState.getLinkablePages()}
-              onLinkPage={inspectorState.onLinkPage}
+              onLinkPageItem={inspectorState.onLinkPageItem}
+              onUnlinkPageItem={inspectorState.onUnlinkPageItem}
             />
           </div>
         </div>

--- a/src/editor/page-inspector/components/PageItemDetails.tsx
+++ b/src/editor/page-inspector/components/PageItemDetails.tsx
@@ -7,13 +7,16 @@ import { Observer, observer } from 'mobx-react';
 import { ColorPicker } from '../../common/inputs/color-picker/ColorPicker';
 import { DetailsSection } from '../../common/dividers/DetailsSection';
 import { NumberInput, NumberInputSize } from '../../common/inputs/number-input/NumberInput';
+import { Page } from '../../common/state/Page';
 import { PageItem } from '../../common/state/PageItem';
+import { PageSelector } from '../../common/inputs/page-selector/PageSelector';
 import { StandardDivider } from '../../common/dividers/StandardDivider';
 import { TextAlign, TextDecoration } from '../../common/state/TextSettings';
 import { TextAreaInput } from '../../common/inputs/text-area-input/TextAreaInput';
 
 interface Props {
   pageItem: PageItem | undefined;
+  linkablePages: Page[];
 }
 
 @observer
@@ -30,6 +33,7 @@ export class PageItemDetails extends React.Component<Props> {
         {this.renderTransformSettings()}
         {this.renderBackgroundSettings()}
         {this.renderContentSettings()}
+        {this.renderLinkSettings()}
       </div>
     );
   }
@@ -222,6 +226,31 @@ export class PageItemDetails extends React.Component<Props> {
   }
 
   private renderLinkSettings() {
-    return <DetailsSection title={'Link'} content={<div className={'link-content'}></div>} />;
+    const { linkablePages, pageItem } = this.props;
+
+    const linkedPage = pageItem.linkedPage?.name ?? 'No linked page';
+
+    return (
+      <DetailsSection
+        title={'Linked page'}
+        content={
+          <div className={'link-content'}>
+            <PageSelector
+              pages={linkablePages}
+              onSelect={pageItem.setLinkedPage}
+              noResultsText={'No other pages to link!'}
+              target={<Button text={linkedPage} minimal outlined rightIcon={'chevron-down'} />}
+            />
+            <Button
+              text={'Unlink'}
+              minimal
+              outlined
+              disabled={pageItem.linkedPage === undefined}
+              onClick={pageItem.unlinkPage}
+            />
+          </div>
+        }
+      />
+    );
   }
 }

--- a/src/editor/page-inspector/components/PageItemDetails.tsx
+++ b/src/editor/page-inspector/components/PageItemDetails.tsx
@@ -17,7 +17,8 @@ import { TextAreaInput } from '../../common/inputs/text-area-input/TextAreaInput
 interface Props {
   pageItem: PageItem | undefined;
   linkablePages: Page[];
-  onLinkPage: (toId: string) => void;
+  onLinkPageItem: (itemId: string, toId: string) => void;
+  onUnlinkPageItem: (itemId: string) => void;
 }
 
 @observer
@@ -227,7 +228,7 @@ export class PageItemDetails extends React.Component<Props> {
   }
 
   private renderLinkSettings() {
-    const { linkablePages, pageItem, onLinkPage } = this.props;
+    const { linkablePages, pageItem, onLinkPageItem, onUnlinkPageItem } = this.props;
 
     const linkedPage = pageItem.linkedPage?.name ?? 'No linked page';
 
@@ -240,7 +241,7 @@ export class PageItemDetails extends React.Component<Props> {
               pages={linkablePages}
               onSelect={(page: Page) => {
                 pageItem.setLinkedPage(page);
-                onLinkPage(page.id);
+                onLinkPageItem(pageItem.id, page.id);
               }}
               noResultsText={'No other pages to link!'}
               target={<Button text={linkedPage} minimal outlined rightIcon={'chevron-down'} />}
@@ -250,7 +251,10 @@ export class PageItemDetails extends React.Component<Props> {
               minimal
               outlined
               disabled={pageItem.linkedPage === undefined}
-              onClick={pageItem.unlinkPage}
+              onClick={() => {
+                pageItem.unlinkPage();
+                onUnlinkPageItem(pageItem.id);
+              }}
             />
           </div>
         }

--- a/src/editor/page-inspector/components/PageItemDetails.tsx
+++ b/src/editor/page-inspector/components/PageItemDetails.tsx
@@ -17,6 +17,7 @@ import { TextAreaInput } from '../../common/inputs/text-area-input/TextAreaInput
 interface Props {
   pageItem: PageItem | undefined;
   linkablePages: Page[];
+  onLinkPage: (toId: string) => void;
 }
 
 @observer
@@ -226,7 +227,7 @@ export class PageItemDetails extends React.Component<Props> {
   }
 
   private renderLinkSettings() {
-    const { linkablePages, pageItem } = this.props;
+    const { linkablePages, pageItem, onLinkPage } = this.props;
 
     const linkedPage = pageItem.linkedPage?.name ?? 'No linked page';
 
@@ -237,7 +238,10 @@ export class PageItemDetails extends React.Component<Props> {
           <div className={'link-content'}>
             <PageSelector
               pages={linkablePages}
-              onSelect={pageItem.setLinkedPage}
+              onSelect={(page: Page) => {
+                pageItem.setLinkedPage(page);
+                onLinkPage(page.id);
+              }}
               noResultsText={'No other pages to link!'}
               target={<Button text={linkedPage} minimal outlined rightIcon={'chevron-down'} />}
             />

--- a/src/editor/page-inspector/components/PageItemDetails.tsx
+++ b/src/editor/page-inspector/components/PageItemDetails.tsx
@@ -220,4 +220,8 @@ export class PageItemDetails extends React.Component<Props> {
       />
     );
   }
+
+  private renderLinkSettings() {
+    return <DetailsSection title={'Link'} content={<div className={'link-content'}></div>} />;
+  }
 }

--- a/src/editor/page-inspector/components/page-item-details.scss
+++ b/src/editor/page-inspector/components/page-item-details.scss
@@ -6,32 +6,6 @@
   display: flex;
   flex-direction: column;
 
-  .section {
-    padding: 10px;
-    border-bottom: 1px solid $mainBorderColor;
-
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-
-    .section-title {
-      font-weight: bold;
-      user-select: none;
-    }
-
-    .section-column {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 5px;
-    }
-  }
-
-  .transform .section-content {
-    display: flex;
-    gap: 20px;
-  }
-
   .transform-content {
     display: flex;
     gap: 20px;
@@ -54,10 +28,5 @@
       align-items: center;
       gap: 10px;
     }
-  }
-
-  .background .section-content {
-    display: flex;
-    gap: 5px;
   }
 }

--- a/src/editor/page-inspector/components/page-item-details.scss
+++ b/src/editor/page-inspector/components/page-item-details.scss
@@ -29,4 +29,9 @@
       gap: 10px;
     }
   }
+
+  .link-content {
+    display: flex;
+    gap: 5px;
+  }
 }

--- a/src/editor/page-inspector/state/PageInspectorState.ts
+++ b/src/editor/page-inspector/state/PageInspectorState.ts
@@ -28,12 +28,20 @@ export class PageInspectorState extends TabBaseState {
     this.selectedPage = page;
   };
 
-  public onLinkPage = (toId: string) => {
+  public onLinkPageItem = (itemId: string, toId: string) => {
     // The 'from' page is the currently selected page
     storyObserver.fireEvent({
-      type: StoryEventType.LINK_PAGES,
+      type: StoryEventType.LINK_PAGE_ITEM,
+      itemId,
       fromId: this.selectedPage.id,
       toId,
+    });
+  };
+
+  public onUnlinkPageItem = (itemId: string) => {
+    storyObserver.fireEvent({
+      type: StoryEventType.UNLINK_PAGE_ITEM,
+      itemId,
     });
   };
 }

--- a/src/editor/page-inspector/state/PageInspectorState.ts
+++ b/src/editor/page-inspector/state/PageInspectorState.ts
@@ -2,6 +2,7 @@ import { action, observable } from 'mobx';
 
 import { Page } from '../../common/state/Page';
 import { PanelTab } from '../../editor-root/state/EditorRootState';
+import { StoryEventType, storyObserver } from '../../events/StoryEventObserver';
 import { TabBaseState } from '../../editor-root/state/TabBaseState';
 
 export class PageInspectorState extends TabBaseState {
@@ -25,5 +26,14 @@ export class PageInspectorState extends TabBaseState {
 
   @action public setSelectedPage = (page: Page) => {
     this.selectedPage = page;
+  };
+
+  public onLinkPage = (toId: string) => {
+    // The 'from' page is the currently selected page
+    storyObserver.fireEvent({
+      type: StoryEventType.LINK_PAGES,
+      fromId: this.selectedPage.id,
+      toId,
+    });
   };
 }

--- a/src/editor/page-inspector/state/PageInspectorState.ts
+++ b/src/editor/page-inspector/state/PageInspectorState.ts
@@ -18,6 +18,11 @@ export class PageInspectorState extends TabBaseState {
     // and send that in this constructor when creating the tab
   }
 
+  public getLinkablePages() {
+    // For the inspected page link items link options - cannot link to same page
+    return this.pages.filter((page) => page.id !== this.selectedPage.id);
+  }
+
   @action public setSelectedPage = (page: Page) => {
     this.selectedPage = page;
   };

--- a/src/editor/story-graph/state/StoryGraphState.ts
+++ b/src/editor/story-graph/state/StoryGraphState.ts
@@ -1,11 +1,14 @@
-import { FlowElement, Node } from 'react-flow-renderer';
+import { Edge, FlowElement, Node } from 'react-flow-renderer';
 import { action, observable } from 'mobx';
 
 import { Page } from '../../common/state/Page';
+import { RandomUtils } from '../../../utils/RandomUtils';
 import { StoryEvent, StoryEventType, storyObserver } from '../../events/StoryEventObserver';
+import { Vector } from '../../../utils/Vector';
 
 export class StoryGraphState {
   @observable.ref public elements: FlowElement[] = [];
+  private lastNodePos = new Vector(100, 20);
 
   constructor() {
     storyObserver.addGameEventListener(this.storyEventListener);
@@ -19,17 +22,22 @@ export class StoryGraphState {
       case StoryEventType.RENAME_PAGE:
         this.onRenamePage(event.page);
         break;
+      case StoryEventType.LINK_PAGES:
+        this.onLinkPages(event.fromId, event.toId);
+        break;
     }
   };
 
-  private onNewPage(page: Page) {
+  @action private onNewPage(page: Page) {
     const type = this.elements.length ? 'default' : 'input';
+
+    this.lastNodePos.add(new Vector(0, 100));
 
     const node: Node = {
       id: page.id,
       type,
       data: { label: page.name },
-      position: { x: 0, y: 0 },
+      position: { x: this.lastNodePos.x, y: this.lastNodePos.y },
     };
 
     this.elements.push(node);
@@ -50,20 +58,15 @@ export class StoryGraphState {
     });
   }
 
-  @action public addPageNode(id: string, name: string) {
-    // Only first node is of type input
-    const type = this.elements.length ? 'default' : 'input';
-
-    const node: Node = {
-      id,
-      type,
-      data: { label: name },
-      position: { x: 70, y: 30 },
+  @action public onLinkPages(fromId: string, toId: string) {
+    const edge: Edge = {
+      id: RandomUtils.createId(),
+      source: fromId,
+      target: toId,
     };
 
-    this.elements.push(node);
+    this.elements.push(edge);
 
-    // Must overwrite elements to update renderer
-    this.elements = this.elements.map((el) => el);
+    this.elements = [...this.elements];
   }
 }

--- a/src/editor/story-graph/state/StoryGraphState.ts
+++ b/src/editor/story-graph/state/StoryGraphState.ts
@@ -8,7 +8,7 @@ import { Vector } from '../../../utils/Vector';
 
 export class StoryGraphState {
   @observable.ref public elements: FlowElement[] = [];
-  private lastNodePos = new Vector(100, 20);
+  private lastNodePos = new Vector(100, -80);
 
   constructor() {
     storyObserver.addGameEventListener(this.storyEventListener);
@@ -22,9 +22,11 @@ export class StoryGraphState {
       case StoryEventType.RENAME_PAGE:
         this.onRenamePage(event.page);
         break;
-      case StoryEventType.LINK_PAGES:
-        this.onLinkPages(event.fromId, event.toId);
+      case StoryEventType.LINK_PAGE_ITEM:
+        this.onLinkPages(event.itemId, event.fromId, event.toId);
         break;
+      case StoryEventType.UNLINK_PAGE_ITEM:
+        this.onUnlinkPages(event.itemId);
     }
   };
 
@@ -58,9 +60,9 @@ export class StoryGraphState {
     });
   }
 
-  @action public onLinkPages(fromId: string, toId: string) {
+  @action public onLinkPages(linkId: string, fromId: string, toId: string) {
     const edge: Edge = {
-      id: RandomUtils.createId(),
+      id: linkId,
       source: fromId,
       target: toId,
     };
@@ -68,5 +70,9 @@ export class StoryGraphState {
     this.elements.push(edge);
 
     this.elements = [...this.elements];
+  }
+
+  @action public onUnlinkPages(linkId: string) {
+    this.elements = this.elements.filter((element) => element.id !== linkId);
   }
 }


### PR DESCRIPTION
- adds a 'linked pages' section to page inspector for selected page item
- allows (un)linking that item to a page other than the page the item is on
- updates the story graph to show connected nodes