### PR TITLE
FRONT-15: added collapse sections to details section comp

### DIFF
--- a/src/AppState.ts
+++ b/src/AppState.ts
@@ -20,6 +20,7 @@ export class AppState {
 
   // Used in development; quick way to route to a location in the app
   private devOnlyRoute() {
-    this.websiteRootState.toPage(WebsitePage.MY_STORIES);
+    this.appScreen = AppScreen.EDITOR;
+    //this.websiteRootState.toPage(WebsitePage.MY_STORIES);
   }
 }

--- a/src/editor/common/components/dividers/DetailsSection.tsx
+++ b/src/editor/common/components/dividers/DetailsSection.tsx
@@ -1,21 +1,36 @@
 import './details-section.scss';
 
 import React from 'react';
+import { Collapse, Icon } from '@blueprintjs/core';
+import { action, observable } from 'mobx';
+import { observer } from 'mobx-react';
 
 interface Props {
   title: string;
   content: JSX.Element;
 }
 
+@observer
 export class DetailsSection extends React.Component<Props> {
+  @observable isOpen = false;
+
   public render() {
     const { title, content } = this.props;
 
     return (
       <div className={'details-section'}>
-        <div className={'details-section-title'}>{title}</div>
-        <div className={'details-section-content'}>{content}</div>
+        <div className={'details-section-title'} onClick={this.onClickTitle}>
+          <Icon icon={this.isOpen ? 'chevron-down' : 'chevron-right'} />
+          {title}
+        </div>
+        <Collapse isOpen={this.isOpen}>
+          <div className={'details-section-content'}>{content}</div>
+        </Collapse>
       </div>
     );
   }
+
+  @action private onClickTitle = () => {
+    this.isOpen = !this.isOpen;
+  };
 }

--- a/src/editor/common/components/dividers/details-section.scss
+++ b/src/editor/common/components/dividers/details-section.scss
@@ -6,10 +6,18 @@
 
   display: flex;
   flex-direction: column;
-  gap: 5px;
 
   .details-section-title {
     font-weight: bold;
     user-select: none;
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .details-section-content {
+    margin-top: 5px;
   }
 }

--- a/src/editor/common/components/inputs/editable-text/EditableText.tsx
+++ b/src/editor/common/components/inputs/editable-text/EditableText.tsx
@@ -50,6 +50,7 @@ export class EditableText extends React.Component<Props> {
         label={label}
         inline={inline ?? false}
         helperText={this.invalid ? `Must be at least ${minLength} characters` : ''}
+        style={{ margin: '0' }}
       >
         <div className={'editable-text-container ' + className}>{content}</div>
       </FormGroup>


### PR DESCRIPTION
Small PR, adds collapsable behaviour to the details sections for the page inspector:

![image](https://user-images.githubusercontent.com/13798027/141520686-ae6e41f0-8a1e-47ae-af96-21ae54821669.png)
