### PR TITLE
FRONT-22: added toast manager and toasts for save layout, create page

### DIFF
--- a/src/editor/editor-root/state/EditorRootState.ts
+++ b/src/editor/editor-root/state/EditorRootState.ts
@@ -14,6 +14,7 @@ import { Story } from '../../common/state/Story';
 import { StoryGraphState } from '../../story-graph/state/StoryGraphState';
 import { StoryModel } from '../../common/model/StoryModel';
 import { TabBaseState } from './TabBaseState';
+import { toastManager } from '../../../utils/ToastManager';
 
 export interface PanelTab extends DuiPanelTab {
   type: PanelTabType;
@@ -71,6 +72,8 @@ export class EditorRootState {
     page.setName(name);
 
     this.story.addPage(page);
+
+    toastManager.successToast('Created new page ' + name);
   };
 
   public startSaveLayout = () => {
@@ -105,6 +108,8 @@ export class EditorRootState {
 
     // Then save the layout
     this.editorStorage.saveUserLayout(layoutModel);
+
+    toastManager.successToast('Saved layout ' + name);
   };
 
   public loadLayout(layoutModel: LayoutModel) {

--- a/src/utils/ToastManager.ts
+++ b/src/utils/ToastManager.ts
@@ -1,0 +1,25 @@
+import { Intent, Position, Toaster } from '@blueprintjs/core';
+
+class ToastManager {
+  private toaster = Toaster.create({
+    position: Position.TOP,
+  });
+
+  public successToast(message: string) {
+    this.toaster.show({ message, intent: Intent.SUCCESS });
+  }
+
+  public toast(message: string) {
+    this.toaster.show({ message });
+  }
+
+  public warnToast(message: string) {
+    this.toaster.show({ message, intent: Intent.WARNING });
+  }
+
+  public errorToast(message: string) {
+    this.toaster.show({ message, intent: Intent.DANGER });
+  }
+}
+
+export const toastManager = new ToastManager();


### PR DESCRIPTION
- added a toast manager singleton which hooks up to Blueprints toaster
- provides 4 methods for the various toast types; normal, success, warn, error
- added in two toasts for Save Layout and Add Page operations